### PR TITLE
fix(theme): Use resolvedTheme in form component to correctly reflect …

### DIFF
--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import dynamic from "next/dynamic";
 
 export function ModeToggleBase() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme: theme, setTheme } = useTheme();
   return (
     <Button
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}


### PR DESCRIPTION
Fixes an issue where the page incorrectly renders in light theme on initial load despite the system being in dark mode. Updated the ModeToggleBase component to use `resolvedTheme` from `next-themes` instead of `theme`.

**Changes**:
- Replaced `theme` with `resolvedTheme` in ModeToggleBase component for accurate theme detection.

**Steps to Reproduce Issue**:
1. Open the page in a **private/incognito window** (to clear stored theme preferences).
2. Ensure system theme is set to dark mode.
3. Observe the page renders in light theme initially (issue).

**Steps to Verify Fix**:
1. Open the page in a private window with system dark mode enabled.
2. Confirm the page renders in dark theme on initial load.
3. Toggle theme and refresh to ensure consistent behavior.

**Testing**:
- Tested in private window with dark/light system themes.

**Attachments**:
<img width="2546" height="636" alt="image" src="https://github.com/user-attachments/assets/93acd08f-2210-4aac-9c1f-564dffd483d2" />
