### PR TITLE
feat: persist selected package manager in local storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "formcn-tanstack",

--- a/src/components/shared/package-manager-tabs.tsx
+++ b/src/components/shared/package-manager-tabs.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react'
+import { useLocalStorage } from '@mantine/hooks'
 import { SiBun, SiNpm, SiPnpm, SiYarn } from 'react-icons/si'
 import { CopyButton } from '@/components/copy-button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+const STORAGE_KEY = 'formcn-package-manager'
 
 const prefixes = {
 	pnpm: 'pnpx shadcn@latest add',
@@ -20,7 +22,10 @@ export const PackagesManagerTabs = ({ packages }: { packages: string }) => {
 		...o,
 		value: prefixes[o.command as keyof typeof prefixes] + ' ' + o.value,
 	}))
-	const [activeTab, setActiveTab] = React.useState('pnpm')
+	const [activeTab, setActiveTab] = useLocalStorage({
+		key: STORAGE_KEY,
+		defaultValue: 'pnpm',
+	})
 	return (
 		<Tabs
 			defaultValue="pnpm"


### PR DESCRIPTION
## Summary
Persist the user's selected package manager (pnpm/npm/yarn/bun) in local storage so it remembers their preference across page reloads.

## Problem
Closes #24

Currently, the package manager tabs always default to `pnpm` on every page load. Users who prefer a different package manager have to re-select it each time.

## Solution
- Replace `React.useState` with `useLocalStorage` from `@mantine/hooks` (already a project dependency)
- Store the preference under the key `formcn-package-manager`
- Default remains `pnpm` for first-time visitors

## Testing
- [x] `bun run build` passes
- [x] `biome check` passes on modified file
- [x] No new dependencies added (uses existing `@mantine/hooks`)

## Changes
- `src/components/shared/package-manager-tabs.tsx`: 8 lines changed

Made with [Cursor](https://cursor.com)